### PR TITLE
Correct decoding for (signed) Steering Wheel Angle [deg], etc.

### DIFF
--- a/CAR-can_AZE0.dbc
+++ b/CAR-can_AZE0.dbc
@@ -45,8 +45,8 @@ BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
  SG_ NewSignal_0089 : 9|1@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 2 x002: 5 STRG
- SG_ SteeringAngle : 7|16@0+ (1,0) [0|0] "ddeg" Vector__XXX
- SG_ SteeringAngleChangeRate : 23|8@0+ (1,0) [0|0] "" Vector__XXX
+ SG_ SteeringAngle : 0|16@1- (0.1,0) [-3276.8|3276.7] "deg" Vector__XXX
+ SG_ SteeringAngleChangeRate : 23|8@0+ (1,0) [0|255] "" Vector__XXX
  SG_ Unknown_2_3 : 31|8@0+ (1,0) [0|0] "" Vector__XXX
  SG_ SteeringSensorHearbeat : 39|8@0+ (1,0) [0|0] "" Vector__XXX
 
@@ -90,10 +90,10 @@ BO_ 384 x180: 8 VCM
  SG_ Unknown_180_7 : 0|8@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 458 x1CA: 8 BRAKE
- SG_ BrakePressure1 : 0|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ BrakePressure2 : 8|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ BrakePressure3 : 16|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ BrakePressure4 : 24|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BrakePressure1 : 0|8@1+ (0.5,0) [0|100] "%" Vector__XXX
+ SG_ BrakePressure2 : 8|8@1+ (0.5,0) [0|100] "%" Vector__XXX
+ SG_ BrakePressure3 : 16|8@1+ (0.5,0) [0|100] "%" Vector__XXX
+ SG_ BrakePressure4 : 24|8@1+ (0.5,0) [0|100] "%" Vector__XXX
  SG_ Unknown_1CA_4 : 32|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ RegenBraking : 42|6@1+ (1,0) [0|0] "" Vector__XXX
  SG_ Unknown_1CA_5_2 : 40|2@1+ (1,0) [0|0] "" Vector__XXX
@@ -156,7 +156,7 @@ BO_ 640 x280: 8 MA
  SG_ Unknown_280_1 : 8|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ Unknown_280_2 : 16|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ Unknown_280_3 : 24|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ VehicleSpeedCluster : 39|16@0+ (1,0) [0|0] "" Vector__XXX
+ SG_ VehicleSpeedCluster : 39|16@0+ (0.01,0) [0|655.35] "km/h" Vector__XXX
  SG_ Unknown_280_6 : 48|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ Unknown_280_7 : 56|8@1+ (1,0) [0|0] "" Vector__XXX
 
@@ -514,6 +514,7 @@ CM_ BU_ IPDMer "Intelligent Power Distribution Module Engine Room";
 CM_ BU_ BRAKE "Electrically-driven intelligent brake unit";
 CM_ BU_ ABS "ABS actuator and electric control unit";
 CM_ BU_ VCM "Vehicle Control Module";
+CM_ BO_ 3221225472 "This is a message for not used signals, created by Vector CANdb++ DBC OLE DB Provider.";
 CM_ BO_ 2 "Steering angle sensor signal. Goes to AV unit, Brake, and ABS modules";
 CM_ SG_ 2 SteeringAngle "Steering Angle LSB:MSB
 Left is negative
@@ -525,7 +526,6 @@ CM_ BO_ 42 "???";
 CM_ SG_ 42 Unknown_2A_0 "Always 0?";
 CM_ SG_ 42 Unknown_2A_1 "Always 0?";
 CM_ SG_ 42 Unknown_2A_2 "Always 0?";
-CM_ BO_ 304 "";
 CM_ SG_ 304 BitmaskABS "Bit5 = 1 = Traction control off?";
 CM_ BO_ 372 "Relayed from E-Shift on EV-CAN";
 CM_ SG_ 372 ShifterPosition "AA:Park/Neutral BB:Drive 99:Reverse";


### PR DESCRIPTION
This pull request adds correct decoding for the Steering Wheel Angle [deg], Brake Pressure [%] Vehicle Speed [km/h].

Especially the  Steering Wheel Angle decoding was correctly mentioned in the excel table but incorrectly implemented in the CAR-can_AZE0.dbc file. 

I don't know if there are differences between the Nissan Leaf models, but the decoding works with our Nissan Leaf ZE0.