### PR TITLE
MotorAmp should be a signed quantity

### DIFF
--- a/CAR-can_AZE0.dbc
+++ b/CAR-can_AZE0.dbc
@@ -85,8 +85,8 @@ BO_ 374 x176: 7 Vector__XXX
 BO_ 384 x180: 8 VCM
  SG_ Unknown_180_0 : 0|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ Unknown_180_1 : 8|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ MotorAmp : 23|16@0+ (1,0) [0|0] "" Vector__XXX
- SG_ MotorAmpAlternative : 32|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MotorAmp : 23|12@0- (1,0) [0|0] "" Vector__XXX
+ SG_ MotorAmpAlternative : 27|12@0- (1,0) [0|0] "" Vector__XXX
  SG_ ThrottlePosition : 40|8@1+ (0.5,0) [0|100] "%" Vector__XXX
  SG_ Unknown_180_5 : 48|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ Unknown_180_6 : 56|8@1+ (1,0) [0|0] "" Vector__XXX


### PR DESCRIPTION
"CAR-can_AZE0.dbc" currently (no pun intended) indicates the two MotorAmp quantities as unsigned.  This is clearly not the case, as the car can both expend energy or recover it in regeneration.

I'm also suspect of the present encoding of MotorAmp and MotorAmpAlternative as 16-bit and 8-bit respectively.  I only have a ZE0 (not a AZE0), but the data I see corresponds with two 12-bit quantities.